### PR TITLE
Hash Query

### DIFF
--- a/src/automattic/vip/hash/DataModel.php
+++ b/src/automattic/vip/hash/DataModel.php
@@ -14,7 +14,7 @@ interface DataModel {
 	 * @param  HashRecord $hash the hash to be saved
 	 * @return bool successful?
 	 */
-	public function saveHash( HashRecord $hash );
+	public function saveHash( HashRecord $hash ) : bool;
 
 	/**
 	 * @param $file
@@ -54,7 +54,7 @@ interface DataModel {
 	 * @param  Remote $remote the remote data store to add
 	 * @return bool
 	 */
-	public function addRemote( Remote $remote );
+	public function addRemote( Remote $remote ) : bool;
 
 	/**
 	 * @param Remote $remote
@@ -62,14 +62,14 @@ interface DataModel {
 	 * @param  Remote $remote the remote datastore to update
 	 * @return bool
 	 */
-	public function updateRemote( Remote $remote );
+	public function updateRemote( Remote $remote ) : bool;
 
 	/**
 	 * remove a remote
 	 * @param  Remote $remote [description]
 	 * @return bool
 	 */
-	public function removeRemote( Remote $remote );
+	public function removeRemote( Remote $remote ): bool;
 
 	/**
 	 * @return Remote[]
@@ -90,4 +90,10 @@ interface DataModel {
 	 * @return Config the config object
 	 */
 	public function config() : config\Config;
+
+	/**
+	 * Returns a Hash Query object
+	 * @return HashQuery a new query for fetching hashes
+	 */
+	public function newQuery() : HashQuery;
 }

--- a/src/automattic/vip/hash/NullDataModel.php
+++ b/src/automattic/vip/hash/NullDataModel.php
@@ -22,7 +22,7 @@ class NullDataModel implements DataModel {
 	 *
 	 * @return bool successful?
 	 */
-	public function saveHash( HashRecord $hash ) {
+	public function saveHash( HashRecord $hash ) : bool {
 		return false;
 	}
 
@@ -97,7 +97,7 @@ class NullDataModel implements DataModel {
 	 * @internal param int $last_sent
 	 *
 	 */
-	public function addRemote( Remote $remote ) {
+	public function addRemote( Remote $remote ) : bool {
 		return false;
 	}
 
@@ -112,11 +112,11 @@ class NullDataModel implements DataModel {
 	 * @internal param int $last_sent
 	 *
 	 */
-	public function updateRemote( Remote $remote ) {
+	public function updateRemote( Remote $remote ) : bool {
 		return false;
 	}
 
-	public function removeRemote( Remote $remote ) {
+	public function removeRemote( Remote $remote ) : bool {
 		return false;
 	}
 
@@ -143,5 +143,13 @@ class NullDataModel implements DataModel {
 	 */
 	public function config() : config\Config {
 		return new config\NullConfig();
+	}
+
+	/**
+	 * Returns a Hash Query object
+	 * @return HashQuery a new query for fetching hashes
+	 */
+	public function newQuery() : HashQuery {
+		return new NullHashQuery();
 	}
 }

--- a/src/automattic/vip/hash/hash-query.php
+++ b/src/automattic/vip/hash/hash-query.php
@@ -2,11 +2,35 @@
 
 namespace automattic\vip\hash;
 
-
+/**
+ * An interface for fetching hashes from a data store
+ */
 interface HashQuery {
-	//
+	/**
+	 * Fetches hashes given arguments
+	 * 
+	 * @param  array  $arguments A dictionary array containing parameters for what hashes to apc_fetch
+	 * @return  bool              True if the hashes were fetched false for anything else, may throw exceptions
+	 */
 	public function fetch( array $arguments ) : bool;
+
+	/**
+	 * The number of pages if pagination is enabled
+	 * @return int 0 if an error occurred, 1 if pagination is off, more if pagination is enabled
+	 */
 	public function totalPages() : int;
+
+	/**
+	 * An array of the found hashes
+	 * 
+	 * @return array An array of the hashes found when `fetch` was called, will be empty if that hasn't happened yet
+	 */
 	public function hashes() : array;
+
+	/**
+	 * How many hashes were fetched
+	 * 
+	 * @return int Number of hashes fetched
+	 */
 	public function hashCount() : int;
 }

--- a/src/automattic/vip/hash/hash-query.php
+++ b/src/automattic/vip/hash/hash-query.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace automattic\vip\hash;
+
+
+interface HashQuery {
+	//
+	public function fetch( array $arguments ) : bool;
+	public function totalPages() : int;
+	public function hashes() : array;
+	public function hashCount() : int;
+}

--- a/src/automattic/vip/hash/null-hash-query.php
+++ b/src/automattic/vip/hash/null-hash-query.php
@@ -4,15 +4,30 @@ namespace automattic\vip\hash;
 
 
 class NullHashQuery implements HashQuery {
+	/**
+	 * @inherit
+	 */
 	public function fetch( array $arguments ) : bool {
 		return false;
 	}
+
+	/**
+	 * @inherit
+	 */
 	public function totalPages() : int {
 		return 0;
 	}
+
+	/**
+	 * @inherit
+	 */
 	public function hashes() : array {
 		return [];
 	}
+	
+	/**
+	 * @inherit
+	 */
 	public function hashCount() : int {
 		return 0;
 	}

--- a/src/automattic/vip/hash/null-hash-query.php
+++ b/src/automattic/vip/hash/null-hash-query.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace automattic\vip\hash;
+
+
+class NullHashQuery implements HashQuery {
+	public function fetch( array $arguments ) : bool {
+		return false;
+	}
+	public function totalPages() : int {
+		return 0;
+	}
+	public function hashes() : array {
+		return [];
+	}
+	public function hashCount() : int {
+		return 0;
+	}
+}

--- a/src/automattic/vip/hash/pdo-data-model.php
+++ b/src/automattic/vip/hash/pdo-data-model.php
@@ -219,19 +219,13 @@ class Pdo_Data_Model extends NullDataModel {
 	}
 
 	public function getHashesSeenAfter( $date ) {
-		$date = intval( $date );
-		$results = $this->pdo->query( "SELECT * FROM wpcom_vip_hashes WHERE seen > $date ORDER BY seen ASC" );
-		if ( ! $results ) {
-			$error_info = print_r( $this->pdo->errorInfo(), true );
-			throw new \Exception( $error_info );
-		}
-
-		$output_data = array();
-		while ( $row = $results->fetch( PDO::FETCH_ASSOC ) ) {
-			unset( $row['id'] );
-			$output_data[] = $row;
-		}
-		return $output_data;
+		$query = $this->newQuery();
+		$query->fetch([
+			'seen' => [
+				'after' => intval( $date )
+			]
+		]);
+		return $query->hashes();
 	}
 
 

--- a/src/automattic/vip/hash/pdo-data-model.php
+++ b/src/automattic/vip/hash/pdo-data-model.php
@@ -117,19 +117,13 @@ class Pdo_Data_Model extends NullDataModel {
 	 * @throws \Exception
 	 */
 	public function getHashStatusByUser( $hash, $username ) {
-		$results = $this->pdo->query( "SELECT * FROM wpcom_vip_hashes WHERE hash = '$hash' AND user = '$username'" );
 
-		if ( ! $results ) {
-			$error_info = print_r( $this->pdo->errorInfo(), true );
-			throw new \Exception( $error_info, $this->pdo->errorCode() );
-		}
-
-		$output_data = array();
-		while ( $row = $results->fetch( PDO::FETCH_ASSOC ) ) {
-			unset( $row['id'] );
-			$output_data[] = $row;
-		}
-		return $output_data;
+		$query = $this->newQuery();
+		$query->fetch([
+			'user' => $username,
+			'hash' => $hash
+		]);
+		return $query->hashes();
 	}
 
 	/**
@@ -394,5 +388,12 @@ class Pdo_Data_Model extends NullDataModel {
 	 */
 	public function config() : config\Config {
 		return $this->config;
+	}
+
+	/**
+	 * @inherit
+	 */
+	public function newQuery() : HashQuery {
+		return new \automattic\vip\hash\pdo\PDOHashQuery( $this->pdo );
 	}
 }

--- a/src/automattic/vip/hash/pdo-data-model.php
+++ b/src/automattic/vip/hash/pdo-data-model.php
@@ -46,7 +46,7 @@ class Pdo_Data_Model extends NullDataModel {
 	/**
 	 * @return \PDO
 	 */
-	public function getPDO() {
+	public function getPDO() : \PDO {
 		return $this->pdo;
 	}
 
@@ -59,7 +59,7 @@ class Pdo_Data_Model extends NullDataModel {
 	 * @return bool
 	 * @throws \Exception
 	 */
-	public function saveHash( HashRecord $record ) {
+	public function saveHash( HashRecord $record ) : bool {
 		$pdo = $this->getPDO();
 
 		$username = $record->getUsername();
@@ -157,7 +157,7 @@ class Pdo_Data_Model extends NullDataModel {
 	/**
 	 * @return string the folder containing hash records with a trailing slash
 	 */
-	public function getDBDir() {
+	public function getDBDir() : string {
 
 		if ( ! empty( $this->dbdir ) ) {
 			return $this->dbdir;
@@ -186,7 +186,7 @@ class Pdo_Data_Model extends NullDataModel {
 	 * 
 	 * @return array an array of strings representing folder paths
 	 */
-	protected function searchDBFolders() {
+	protected function searchDBFolders() : array {
 		$folders = [];
 		if ( ! empty( $_SERVER['HOME'] ) ) {
 			$folders[] = $_SERVER['HOME'] . DIRECTORY_SEPARATOR . '.viphash' . DIRECTORY_SEPARATOR;
@@ -205,6 +205,9 @@ class Pdo_Data_Model extends NullDataModel {
 		return $folders;
 	}
 
+	/**
+	 * @inherit
+	 */
 	public function getNewestSeenHash() {
 		$results = $this->pdo->query( 'SELECT * FROM wpcom_vip_hashes ORDER BY seen DESC LIMIT 1' );
 		if ( ! $results ) {
@@ -259,7 +262,7 @@ class Pdo_Data_Model extends NullDataModel {
 	 * @return bool
 	 * @throws \Exception
 	 */
-	public function addRemote( Remote $remote ) {
+	public function addRemote( Remote $remote ) : bool {
 
 		$name = $remote->getName();
 		$uri = $remote->getUri();
@@ -292,7 +295,7 @@ class Pdo_Data_Model extends NullDataModel {
 		return true;
 	}
 
-	public function updateRemote( Remote $remote ) {
+	public function updateRemote( Remote $remote ) : bool {
 		$id = $remote->getId();
 		$name = $remote->getName();
 		$uri = $remote->getUri();
@@ -327,7 +330,7 @@ class Pdo_Data_Model extends NullDataModel {
 		return true;
 	}
 
-	public function removeRemote( Remote $remote ) {
+	public function removeRemote( Remote $remote ) : bool {
 		$name = $remote->getName();
 		// it's old, update it
 		// //UPDATE Cars SET Name='Skoda Octavia' WHERE Id=3;

--- a/src/automattic/vip/hash/pdo-data-model.php
+++ b/src/automattic/vip/hash/pdo-data-model.php
@@ -209,19 +209,13 @@ class Pdo_Data_Model extends NullDataModel {
 	}
 
 	public function getHashesAfter( $date ) {
-		$date = intval( $date );
-		$results = $this->pdo->query( "SELECT * FROM wpcom_vip_hashes WHERE date > $date ORDER BY date ASC" );
-		if ( ! $results ) {
-			$error_info = print_r( $this->pdo->errorInfo(), true );
-			throw new \Exception( $error_info );
-		}
-
-		$output_data = array();
-		while ( $row = $results->fetch( PDO::FETCH_ASSOC ) ) {
-			unset( $row['id'] );
-			$output_data[] = $row;
-		}
-		return $output_data;
+		$query = $this->newQuery();
+		$query->fetch([
+			'date' => [
+				'after' => intval( $date )
+			]
+		]);
+		return $query->hashes();
 	}
 
 	public function getHashesSeenAfter( $date ) {

--- a/src/automattic/vip/hash/pdo-data-model.php
+++ b/src/automattic/vip/hash/pdo-data-model.php
@@ -117,7 +117,6 @@ class Pdo_Data_Model extends NullDataModel {
 	 * @throws \Exception
 	 */
 	public function getHashStatusByUser( $hash, $username ) {
-
 		$query = $this->newQuery();
 		$query->fetch([
 			'user' => $username,
@@ -133,19 +132,11 @@ class Pdo_Data_Model extends NullDataModel {
 	 * @return array
 	 */
 	public function getHashStatusAllUsers( $hash ) {
-		$results = $this->pdo->query( "SELECT * FROM wpcom_vip_hashes WHERE hash = '$hash'" );
-
-		if ( ! $results ) {
-			$error_info = print_r( $this->pdo->errorInfo(), true );
-			throw new \Exception( $error_info );
-		}
-
-		$output_data = array();
-		while ( $row = $results->fetch( PDO::FETCH_ASSOC ) ) {
-			unset( $row['id'] );
-			$output_data[] = $row;
-		}
-		return $output_data;
+		$query = $this->newQuery();
+		$query->fetch([
+			'hash' => $hash
+		]);
+		return $query->hashes();
 	}
 
 	/**

--- a/src/automattic/vip/hash/pdo/pdo-hash-query.php
+++ b/src/automattic/vip/hash/pdo/pdo-hash-query.php
@@ -43,16 +43,44 @@ class PDOHashQuery implements \automattic\vip\hash\HashQuery {
 			$parameters[':user'] = $arguments['user'];
 			$where[] = 'user = :user';
 		}
-		// seen after
+
+		// date
+		if ( !empty( $arguments['date'] ) ) {
+			if ( !empty( $arguments['date']['after'] ) ) {
+				$parameters[':after_date'] = $arguments['date']['after'];
+				$where[] = 'date > :after_date';
+			}
+			if ( !empty( $arguments['date']['before'] ) ) {
+				$parameters[':before_date'] = $arguments['date']['before'];
+				$where[] = 'date < :before_date';
+			}
+		}
+
+		// seen date
+		if ( !empty( $arguments['seen'] ) ) {
+			if ( !empty( $arguments['seen']['after'] ) ) {
+				$parameters[':seen_after_date'] = $arguments['seen']['after'];
+				$where[] = 'seen > :seen_after_date';
+			}
+			if ( !empty( $arguments['seen']['before'] ) ) {
+				$parameters[':seen_before_date'] = $arguments['seen']['before'];
+				$where[] = 'seen < :seen_before_date';
+			}
+		}
 		
 
 		if ( !empty( $where ) ) {
 			$query .= 'WHERE '.implode( ' AND ', $where );
 		}
  
+ 		// order
+		$order = '';
+		$query .= $order;
+		
 		// Figure out the Page/Limit clauses
 		$limits = '';
 		$query .= $limits;
+
 
 		$query = 'SELECT * FROM wpcom_vip_hashes '.$query;
 		

--- a/src/automattic/vip/hash/pdo/pdo-hash-query.php
+++ b/src/automattic/vip/hash/pdo/pdo-hash-query.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace automattic\vip\hash\pdo;
+
+class PDOHashQuery implements HashQuery {
+
+	/**
+	 * PDO
+	 * @var \PDO
+	 */
+	private $pdo;
+	public function __construct( \PDO $pdo ) {
+		$this->pdo = $pdo;
+	}
+}

--- a/src/automattic/vip/hash/pdo/pdo-hash-query.php
+++ b/src/automattic/vip/hash/pdo/pdo-hash-query.php
@@ -2,7 +2,7 @@
 
 namespace automattic\vip\hash\pdo;
 
-class PDOHashQuery implements HashQuery {
+class PDOHashQuery implements \automattic\vip\hash\HashQuery {
 
 	/**
 	 * PDO
@@ -28,7 +28,7 @@ class PDOHashQuery implements HashQuery {
 		$this->arguments = $arguments;
 
 		$parameters = [];
-		$query = 'SELECT * FROM wpcom_vip_hashes ';
+		$query = '';
 		// figure out the WHERE clauses
 		$where = [];
 
@@ -53,24 +53,26 @@ class PDOHashQuery implements HashQuery {
 		// Figure out the Page/Limit clauses
 		$limits = '';
 		$query .= $limits;
+
+		$query = 'SELECT * FROM wpcom_vip_hashes '.$query;
 		
-		$sth = $pdo->prepare( $query );
+		$sth = $this->pdo->prepare( $query );
 		if ( ! $sth ) {
-			$error_info = print_r( $pdo->errorInfo(), true );
+			$error_info = print_r( $this->pdo->errorInfo(), true );
 			throw new \Exception( 'Error creating PDO Hash Query statement ' . $error_info );
 		}
 		$result = $sth->execute( $parameters );
 
 		if ( ! $result ) {
-			$error_info = print_r( $pdo->errorInfo(), true );
-			$error_info_sth = print_r( $sth->errorInfo(), true );
+			$error_info = print_r( $this->pdo->errorInfo(), true );
+			$error_info_sth = print_r( $this->sth->errorInfo(), true );
 			throw new \Exception(
-				"Error executing PDO HashQuery statement\nPDO: #" . $pdo->errorCode() . ' ' . $error_info .
+				"Error executing PDO HashQuery statement\nPDO: #" . $this->pdo->errorCode() . ' ' . $error_info .
 				"\n STH: #" . $sth->errorCode() . ' ' . $error_info_sth .
 				"\n identifier:" . $identifier
 			);
 		}
-		$this->hashes = $sth->fetchAll();
+		$this->hashes = $sth->fetchAll( \PDO::FETCH_ASSOC );
 		unset( $sth );
 		$this->hashes = array_map( function( $hash ) {
 			unset( $hash['id']);

--- a/src/automattic/vip/hash/pdo/pdo-hash-query.php
+++ b/src/automattic/vip/hash/pdo/pdo-hash-query.php
@@ -109,6 +109,7 @@ class PDOHashQuery implements \automattic\vip\hash\HashQuery {
 			unset( $hash['id']);
 			return $hash;
 		}, $this->hashes );
+		$this->pageCount = 1;
 
 		return true;
 	}

--- a/src/automattic/vip/hash/pdo/pdo-hash-query.php
+++ b/src/automattic/vip/hash/pdo/pdo-hash-query.php
@@ -89,7 +89,7 @@ class PDOHashQuery implements \automattic\vip\hash\HashQuery {
 		
 		if ( !empty( $arguments['per_page'] ) ) {
 			$per_page = min( max( intval( $arguments['per_page'] ), 0 ), 1000000);
-			$has_pagination = false;
+			$has_pagination = true;
 		}
 		if ( true === $has_pagination ) {
 			$offset = ( $page -1 ) * $per_page;
@@ -99,17 +99,20 @@ class PDOHashQuery implements \automattic\vip\hash\HashQuery {
 		}
 		$query .= $limits;
 
+		$count_query = 'SELECT count( * ) FROM wpcom_vip_hashes '.$query;
 		$hash_query = 'SELECT * FROM wpcom_vip_hashes '.$query;
 
+		$sth = $this->executeStatement( $count_query, $parameters );
+		$this->pageCount = intval( $sth->fetch( \PDO::FETCH_NUM)[0] );
+
 		$sth = $this->executeStatement( $hash_query, $parameters );
-		
-		$this->hashes = $sth->fetchAll( \PDO::FETCH_ASSOC );
+		$this->hashes = $sth->fetchAll( \PDO::FETCH_ASSOC);
+
 		unset( $sth );
 		$this->hashes = array_map( function( $hash ) {
 			unset( $hash['id']);
 			return $hash;
 		}, $this->hashes );
-		$this->pageCount = 1;
 
 		return true;
 	}

--- a/src/automattic/vip/hash/pdo/pdo-hash-query.php
+++ b/src/automattic/vip/hash/pdo/pdo-hash-query.php
@@ -9,7 +9,95 @@ class PDOHashQuery implements HashQuery {
 	 * @var \PDO
 	 */
 	private $pdo;
+
+	private $hashes;
+	private $arguments;
+	private $pageCount;
+
+
 	public function __construct( \PDO $pdo ) {
 		$this->pdo = $pdo;
+		$this->arguments = $this->hashes = [];
+		$this->pageCount = 0;
+	}
+
+	/**
+	 * @inherit
+	 */
+	public function fetch( array $arguments ) : bool {
+		$this->arguments = $arguments;
+
+		$parameters = [];
+		$query = 'SELECT * FROM wpcom_vip_hashes ';
+		// figure out the WHERE clauses
+		$where = [];
+
+		// particular hash
+		if ( !empty( $arguments['hash'] ) ) {
+			$parameters[':hash'] = $arguments['hash'];
+			$where[] = 'hash = :hash';
+		}
+
+		// particular user
+		if ( !empty( $arguments['user'] ) ) {
+			$parameters[':user'] = $arguments['user'];
+			$where[] = 'user = :user';
+		}
+		// seen after
+		
+
+		if ( !empty( $where ) ) {
+			$query .= 'WHERE '.implode( ' AND ', $where );
+		}
+ 
+		// Figure out the Page/Limit clauses
+		$limits = '';
+		$query .= $limits;
+		
+		$sth = $pdo->prepare( $query );
+		if ( ! $sth ) {
+			$error_info = print_r( $pdo->errorInfo(), true );
+			throw new \Exception( 'Error creating PDO Hash Query statement ' . $error_info );
+		}
+		$result = $sth->execute( $parameters );
+
+		if ( ! $result ) {
+			$error_info = print_r( $pdo->errorInfo(), true );
+			$error_info_sth = print_r( $sth->errorInfo(), true );
+			throw new \Exception(
+				"Error executing PDO HashQuery statement\nPDO: #" . $pdo->errorCode() . ' ' . $error_info .
+				"\n STH: #" . $sth->errorCode() . ' ' . $error_info_sth .
+				"\n identifier:" . $identifier
+			);
+		}
+		$this->hashes = $sth->fetchAll();
+		unset( $sth );
+		$this->hashes = array_map( function( $hash ) {
+			unset( $hash['id']);
+			return $hash;
+		}, $this->hashes );
+
+		return true;
+	}
+
+	/**
+	 * @inherit
+	 */
+	public function totalPages() : int {
+		return $this->pageCount;
+	}
+
+	/**
+	 * @inherit
+	 */
+	public function hashes() : array {
+		return $this->hashes;
+	}
+
+	/**
+	 * @inherit
+	 */
+	public function hashCount() : int {
+		return count( $this->hashes );
 	}
 }


### PR DESCRIPTION
This PR aims to deprecate the DataModel methods that fetch hashes in favour of a new method that returns an object implementing `HashQuery`, which can then be used to fetch hashes in a similar style to `WP_Query`, but with a non-intergalactic NPath complexity

This is needed as a clean way to implement pagination without building a `HashResult` or `HashContainer` object, and tonnes of parameters on the existing methods. This should also help with some REST API issues with memory exhaustion