### PR TITLE
Fixes fatal error due to change from dependency

### DIFF
--- a/src/requestsoauth/requests.php
+++ b/src/requestsoauth/requests.php
@@ -32,7 +32,7 @@ class Requests_Auth_OAuth1 implements Requests_Auth {
 		return $this->consumer;
 	}
 
-	public function register(Requests_Hooks &$hooks) {
+	public function register(Requests_Hooks $hooks) {
 		$hooks->register( 'requests.before_request', array( $this, 'add_headers' ), 1000 );
 	}
 


### PR DESCRIPTION
In 1.8.0, the Requests library updated to remove passing a variable as reference as it was unnecessary.

How to replicate
- `composer install` or `composer update` will update the Requests library to 1.8.1
- Run `php bin/compile` and you will get:

```
Fatal error: Declaration of Requests_Auth_OAuth1::register(Requests_Hooks &$hooks) must be compatible with Requests_Auth::register(Requests_Hooks $hooks) in /Users/mikeyarce/repos/vip-hash/src/requestsoauth/requests.php on line 35
```
If you patch with this PR, compilation should work.